### PR TITLE
[WIP] Translate documentation eslint-plugin-ava in french

### DIFF
--- a/fr_FR/related/eslint-plugin-ava/docs/rules/assertion-message.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/assertion-message.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [assertion-message.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/assertion-message.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/be7c84b3f624016155e446b1dba9eab9a64cd081...master#diff-0b23fa0b3ae6c1f427b3c0f3331ea500) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `assertion-message` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [assertion-message.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/assertion-message.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/be7c84b3f624016155e446b1dba9eab9a64cd081...master#diff-0b23fa0b3ae6c1f427b3c0f3331ea500) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `assertion-message` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # Imposer ou interdir les messages d'assertion
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/assertion-message.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/assertion-message.md
@@ -1,0 +1,52 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [assertion-message.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/assertion-message.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/be7c84b3f624016155e446b1dba9eab9a64cd081...master#diff-0b23fa0b3ae6c1f427b3c0f3331ea500) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `assertion-message` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# Imposer ou interdir les messages d'assertion
+
+Les messages d'assertion sont des arguments facultatifs, qui peuvent être fournis lors de l'appel d'une assertion, pour améliorer le message d'erreur si l'assertion échoue. Cette règle impose ou interdit l'utilisation de ces messages.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+/* eslint ava/assertion-message: ["error", "always"] */
+test(t => {
+	t.true(array.indexOf(value) !== -1);
+});
+
+/* eslint ava/assertion-message: ["error", "never"] */
+test(t => {
+	t.true(array.indexOf(value) !== -1, 'la valeur n\'est pas dans le tableau');
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+/* eslint ava/assertion-message: ["error", "always"] */
+test(t => {
+	t.true(array.indexOf(value) !== -1, 'la valeur n\'est pas dans le tableau');
+});
+
+/* eslint ava/assertion-message: ["error", "never"] */
+test(t => {
+	t.true(array.indexOf(value) !== -1);
+});
+```
+
+## Options
+
+La règle prend une option, un string, qui peut être soit `"always"` (toujours) ou `"never"` (jamais). La valeur par défaut est `"always"`.
+
+Vous pouvez définir l'option dans la configuration comme ceci :
+
+```js
+"ava/assertion-message": ["error", "always"]
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/max-asserts.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/max-asserts.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [max-asserts.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/max-asserts.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-fca60e7ef485498c6b37c6a950f9d59a) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `max-asserts.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [max-asserts.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/max-asserts.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-fca60e7ef485498c6b37c6a950f9d59a) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `max-asserts.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # Limiter le nombre d'assertions dans un test
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/max-asserts.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/max-asserts.md
@@ -1,0 +1,65 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [max-asserts.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/max-asserts.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-fca60e7ef485498c6b37c6a950f9d59a) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `max-asserts.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# Limiter le nombre d'assertions dans un test
+
+Limite la quantité d'assertions dans un test afin d'appliquer le découpage des gros tests en plusieurs plus petits.
+
+Les assertions passées (skip) sont comptés.
+
+
+## Échoue
+
+```js
+/*eslint ava/max-asserts: ["error", 5]*/
+import test = from 'ava';
+
+test('getSomeObject devrait définir le nom du joueur', t => {
+	const object = lib.getSomeObject();
+
+	t.is(typeof object, 'object');
+	t.is(typeof object.player, 'object');
+	t.is(object.player.firstName, 'Luke');
+	t.is(object.player.lastName, 'Skywalker');
+	t.is(typeof object.opponent, 'object');
+	t.is(object.opponent.firstName, 'Darth');
+	t.is(object.opponent.lastName, 'Vader');
+});
+```
+
+
+## Passee
+
+```js
+import test = from 'ava';
+
+test('getSomeObject devrait définir le nom du joueur', t => {
+	const object = lib.getSomeObject();
+
+	t.is(typeof object, 'object');
+	t.is(typeof object.player, 'object');
+	t.is(object.player.firstName, 'Luke');
+	t.is(object.player.lastName, 'Skywalker');
+});
+
+test('getSomeObject devrait définir le nom du joueur', t => {
+	const object = lib.getSomeObject();
+
+	t.is(typeof object, 'object');
+	t.is(typeof object.opponent, 'object');
+	t.is(object.opponent.firstName, 'Darth');
+	t.is(object.opponent.lastName, 'Vader');
+});
+```
+
+## Options
+
+La règle prend une option, un nombre, qui est le nombre maximum d'assertions pour chaque test. La valeur par défaut est 5.
+
+Vous pouvez définir l'option dans la configuration comme ceci :
+
+```js
+"ava/max-asserts": ["error", 5]
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/max-asserts.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/max-asserts.md
@@ -30,7 +30,7 @@ test('getSomeObject devrait définir le nom du joueur', t => {
 ```
 
 
-## Passee
+## Passe
 
 ```js
 import test = from 'ava';

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-cb-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-cb-test.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [max-asserts.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/5146663e536bb7e66bf2a3d044acc3cddebe2d32...master#diff-53d512160f47892d199cb93040332ff7) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-cb-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-cb-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/5146663e536bb7e66bf2a3d044acc3cddebe2d32...master#diff-53d512160f47892d199cb93040332ff7) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-cb-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer qu'aucun `test.cb()` n'est utilisé
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-cb-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-cb-test.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-cb-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/5146663e536bb7e66bf2a3d044acc3cddebe2d32...master#diff-53d512160f47892d199cb93040332ff7) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-cb-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-cb-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/5146663e536bb7e66bf2a3d044acc3cddebe2d32...master#diff-53d512160f47892d199cb93040332ff7) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-cb-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer qu'aucun `test.cb()` n'est utilisé
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-cb-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-cb-test.md
@@ -1,0 +1,31 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [max-asserts.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/5146663e536bb7e66bf2a3d044acc3cddebe2d32...master#diff-53d512160f47892d199cb93040332ff7) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-cb-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer qu'aucun `test.cb()` n'est utilisé
+
+Interdit l'utilisation de `test.cb()`. Nous recommandons plutôt l'utilisation de `test()` avec une fonction async ou une fonction qui retourne une promesse.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test.cb('quelques tests', t => {
+	t.pass();
+	t.end();
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test('quelques tests', async t => {
+	t.pass();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-identical-title.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-identical-title.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-identical-title.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/39bf10ba7ffe7b0b54c7fe636a6d240cd9a48d88...master#diff-71a0207aeafb9ca6c33c3d06982b1baa) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-identical-title.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-identical-title.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-identical-title.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/39bf10ba7ffe7b0b54c7fe636a6d240cd9a48d88...master#diff-71a0207aeafb9ca6c33c3d06982b1baa) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-identical-title.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer que chaque test a un titre différent
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-identical-title.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-identical-title.md
@@ -1,0 +1,42 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [no-identical-title.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-cb-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/39bf10ba7ffe7b0b54c7fe636a6d240cd9a48d88...master#diff-71a0207aeafb9ca6c33c3d06982b1baa) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-identical-title.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que chaque test a un titre différent
+
+Interdit les tests avec des titres identiques car il est difficile de les différencier.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+test('foo', t => {
+	t.pass();
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.pass();
+});
+
+test('foo', t => {
+	t.pass();
+});
+
+test('bar', t => {
+	t.pass();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-identical-title.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-identical-title.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-identical-title.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-identical-title.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/39bf10ba7ffe7b0b54c7fe636a6d240cd9a48d88...master#diff-71a0207aeafb9ca6c33c3d06982b1baa) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-identical-title.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-identical-title.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-identical-title.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/39bf10ba7ffe7b0b54c7fe636a6d240cd9a48d88...master#diff-71a0207aeafb9ca6c33c3d06982b1baa) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-identical-title.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer que chaque test a un titre différent
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
@@ -1,0 +1,92 @@
+# Ensure no tests are written in ignored files
+
+When searching for tests, AVA ignores files contained in `node_modules` or folders named `fixtures` or `helpers`. By default, it will search in `test.js test-*.js test/**/*.js`, which you can override by specifying a path when launching AVA or in the [AVA configuration in the `package.json` file](https://github.com/sindresorhus/ava#configuration).
+
+This rule will verify that files which create tests are in the searched files and not in ignored folders. It will consider the root of the project to be the closest folder containing a `package.json` file, and will not do anything if it can't find one. Test files in `node_modules` will not be linted as they are ignored by ESLint.
+
+Note that this rule will not be able to warn correctly if you use AVA by specifying the files in the command line ( `ava "lib/**/*.test.js"` ). Prefer configuring AVA as described in the link above.
+
+## Échoue
+
+```js
+// File: test/foo/fixtures/bar.js
+// Invalid because in `fixtures` folder
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+// File: test/foo/helpers/bar.js
+// Invalid because in `helpers` folder
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+// File: lib/foo.test.js
+// Invalid because not in the searched files
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+// File: test.js
+// with { "files": ["lib/**/*.test.js", "utils/**/*.test.js"] }
+// in either `package.json` under 'ava key' or in the rule options
+// Invalid because not in the searched files
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+```
+
+
+## Passe
+
+```js
+// File: test/foo/not-fixtures/bar.js
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+// File: test/foo/not-helpers/bar.js
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+// File: test.js
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+// File: lib/foo.test.js
+// with { "files": ["lib/**/*.test.js", "utils/**/*.test.js"] }
+// in either `package.json` under 'ava key' or in the rule options
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+```
+
+## Options
+
+This rule supports the following options:
+
+`files`: An array of strings representing the files glob that AVA will use to find test files. Overrides the default and the configuration found in the `package.json` file.
+
+You can set the options like this:
+
+```js
+"ava/no-ignored-test-files": ["error", {"files": ["lib/**/*.test.js", "utils/**/*.test.js"]}]
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
@@ -5,7 +5,7 @@ C'est la traduction du fichier [no-ignored-test-files.md](https://github.com/sin
 ___
 # S'assurer qu'aucun test ne soit écrit dans des fichiers ignorés
 
-Lors de la recherche des tests, AVA ignore les fichiers contenus dans `node_modules` ou dans les dossiers nommés `fixtures` ou `helpers`. Par défaut, il va chercher dans `test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js`, que vous pouvez remplacer en spécifiant un chemin lors du lancement de AVA ou dans la [configuration de AVA dans le fichier `package.json`](https://github.com/sindresorhus/ava#configuration).
+Lors de la recherche des tests, AVA ignore les fichiers contenus dans `node_modules` ou dans les dossiers nommés `fixtures` ou `helpers`. Par défaut, il va chercher dans `test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js`, que vous pouvez remplacer en spécifiant un chemin lors du lancement de AVA ou dans la [configuration de AVA dans le fichier `package.json`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#configuration).
 
 Cette règle vérifira que les fichiers qui créent des tests sont dans les fichiers recherchés et non dans des dossiers ignorés. Il examinera ç partir de la racine du projet pour être dans le dossier le plus proche contenant un fichier `package.json`, et ne fera rien s'il n'en trouve pas. Les fichiers de test dans `node_modules` ne seront pas vérifiés car ils sont ignorés par ESLint.
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-ignored-test-files.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-ignored-test-files.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-dfdc73f3a1c1fc001ea0161104cf3d13) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-ignored-test-files.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-ignored-test-files.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-ignored-test-files.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/7c949162f705ae2cba3f16acc74e80674555daed...master#diff-dfdc73f3a1c1fc001ea0161104cf3d13) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-ignored-test-files.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer qu'aucun test ne soit écrit dans des fichiers ignorés
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-ignored-test-files.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-ignored-test-files.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-dfdc73f3a1c1fc001ea0161104cf3d13) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-ignored-test-files.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-ignored-test-files.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-ignored-test-files.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-dfdc73f3a1c1fc001ea0161104cf3d13) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-ignored-test-files.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer qu'aucun test ne soit écrit dans des fichiers ignorés
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-ignored-test-files.md
@@ -1,42 +1,47 @@
-# Ensure no tests are written in ignored files
+___
+**Note du traducteur**
 
-When searching for tests, AVA ignores files contained in `node_modules` or folders named `fixtures` or `helpers`. By default, it will search in `test.js test-*.js test/**/*.js`, which you can override by specifying a path when launching AVA or in the [AVA configuration in the `package.json` file](https://github.com/sindresorhus/ava#configuration).
+C'est la traduction du fichier [no-ignored-test-files.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-ignored-test-files.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/ed4057b003e8b1becc085b114830a0177714b7bf...master#diff-dfdc73f3a1c1fc001ea0161104cf3d13) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-ignored-test-files.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer qu'aucun test ne soit écrit dans des fichiers ignorés
 
-This rule will verify that files which create tests are in the searched files and not in ignored folders. It will consider the root of the project to be the closest folder containing a `package.json` file, and will not do anything if it can't find one. Test files in `node_modules` will not be linted as they are ignored by ESLint.
+Lors de la recherche des tests, AVA ignore les fichiers contenus dans `node_modules` ou dans les dossiers nommés `fixtures` ou `helpers`. Par défaut, il va chercher dans `test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js`, que vous pouvez remplacer en spécifiant un chemin lors du lancement de AVA ou dans la [configuration de AVA dans le fichier `package.json`](https://github.com/sindresorhus/ava#configuration).
 
-Note that this rule will not be able to warn correctly if you use AVA by specifying the files in the command line ( `ava "lib/**/*.test.js"` ). Prefer configuring AVA as described in the link above.
+Cette règle vérifira que les fichiers qui créent des tests sont dans les fichiers recherchés et non dans des dossiers ignorés. Il examinera ç partir de la racine du projet pour être dans le dossier le plus proche contenant un fichier `package.json`, et ne fera rien s'il n'en trouve pas. Les fichiers de test dans `node_modules` ne seront pas vérifiés car ils sont ignorés par ESLint.
+
+Notez que cette règle ne pourra pas vous avertir correctement si vous utilisez AVA en spécifiant les fichiers dans la ligne de commande ( `ava "lib/**/*.test.js"` ). Préférez la configuration AVA comme décrite dans le lien ci-dessus.
 
 ## Échoue
 
 ```js
-// File: test/foo/fixtures/bar.js
-// Invalid because in `fixtures` folder
+// Fichier : test/foo/fixtures/bar.js
+// Invalide car dans le répertoire `fixtures`
 import test from 'ava';
 
 test('foo', t => {
 	t.pass();
 });
 
-// File: test/foo/helpers/bar.js
-// Invalid because in `helpers` folder
+// Fichier : test/foo/helpers/bar.js
+// Invalide car dans le répertoire `helpers`
 import test from 'ava';
 
 test('foo', t => {
 	t.pass();
 });
 
-// File: lib/foo.test.js
-// Invalid because not in the searched files
+// Fichier : lib/foo.test.js
+// Invalide car il n'est pas dans les fichiers recherchés
 import test from 'ava';
 
 test('foo', t => {
 	t.pass();
 });
 
-// File: test.js
-// with { "files": ["lib/**/*.test.js", "utils/**/*.test.js"] }
-// in either `package.json` under 'ava key' or in the rule options
-// Invalid because not in the searched files
+// Fichier : test.js
+// avec { "files": ["lib/**/*.test.js", "utils/**/*.test.js"] }
+// soit dans `package.json` sous la 'clef ava' ou dans les options de règle
+// Invalide car il n'est pas dans les fichiers recherchés
 import test from 'ava';
 
 test('foo', t => {
@@ -48,30 +53,30 @@ test('foo', t => {
 ## Passe
 
 ```js
-// File: test/foo/not-fixtures/bar.js
+// Fichier : test/foo/not-fixtures/bar.js
 import test from 'ava';
 
 test('foo', t => {
 	t.pass();
 });
 
-// File: test/foo/not-helpers/bar.js
+// Fichier : test/foo/not-helpers/bar.js
 import test from 'ava';
 
 test('foo', t => {
 	t.pass();
 });
 
-// File: test.js
+// Fichier : test.js
 import test from 'ava';
 
 test('foo', t => {
 	t.pass();
 });
 
-// File: lib/foo.test.js
-// with { "files": ["lib/**/*.test.js", "utils/**/*.test.js"] }
-// in either `package.json` under 'ava key' or in the rule options
+// Fichier : lib/foo.test.js
+// avec { "files": ["lib/**/*.test.js", "utils/**/*.test.js"] }
+// soit dans `package.json` sous la 'clef ava' ou dans les options de règle
 import test from 'ava';
 
 test('foo', t => {
@@ -81,11 +86,11 @@ test('foo', t => {
 
 ## Options
 
-This rule supports the following options:
+Cette règle prend en charge les options suivantes :
 
-`files`: An array of strings representing the files glob that AVA will use to find test files. Overrides the default and the configuration found in the `package.json` file.
+`files`: Un tableau de strings représentant les fichiers glob que nous allons utiliser pour trouver des fichiers de test. Remplace la valeur par défaut et la configuration trouvée dans le fichier de package.json.
 
-You can set the options like this:
+Vous pouvez définir les options comme ceci :
 
 ```js
 "ava/no-ignored-test-files": ["error", {"files": ["lib/**/*.test.js", "utils/**/*.test.js"]}]

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-invalid-end.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-invalid-end.md
@@ -1,6 +1,11 @@
-# Ensure `t.end()` is only called inside `test.cb()`
+___
+**Note du traducteur**
 
-AVA will fail if `t.end()` is called in a non-`cb` test function.
+C'est la traduction du fichier [no-invalid-end.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-invalid-end.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/36e287f467bb01b1877ba9698190a9897434e5e8...master#diff-791776202d9a355f02b808f9b5f4a0fb) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-invalid-end.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que `t.end()` est seulement appelé dans `test.cb()`
+
+AVA échouera si `t.end()` est appelé dans une fonction de test qui n'est pas `cb`.
 
 
 ## Échoue

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-invalid-end.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-invalid-end.md
@@ -1,0 +1,31 @@
+# Ensure `t.end()` is only called inside `test.cb()`
+
+AVA will fail if `t.end()` is called in a non-`cb` test function.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test('quelques tests', t => {
+	t.pass();
+	t.end();
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test('quelques tests', t => {
+	t.pass();
+});
+
+test.cb('quelques tests', t => {
+	t.pass();
+	t.end();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-invalid-end.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-invalid-end.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-invalid-end.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-invalid-end.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/36e287f467bb01b1877ba9698190a9897434e5e8...master#diff-791776202d9a355f02b808f9b5f4a0fb) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-invalid-end.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-invalid-end.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-invalid-end.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/36e287f467bb01b1877ba9698190a9897434e5e8...master#diff-791776202d9a355f02b808f9b5f4a0fb) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-invalid-end.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer que `t.end()` est seulement appelé dans `test.cb()`
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-only-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-only-test.md
@@ -1,0 +1,35 @@
+# Ensure no `test.only()` are present
+
+It's easy to run only one test with `test.only()` and then forget about it. It's visible in the results, but still easily missed. Forgetting to remove `.only`, means only this one test in the whole file will run, and if not caught, can let serious bugs slip into your codebase.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test.only('test 1', t => {
+	t.pass();
+});
+
+// test 2 will not run
+test('test 2', t => {
+	t.pass();
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test('test 1', t => {
+	t.pass();
+});
+
+// test 2 will run
+test('test 2', t => {
+	t.pass();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-only-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-only-test.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [no-only-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-only-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/0c58a71767ca67097321b91f0332f543fc719389...master#diff-b7318d07931729c026fb1f61e9734468) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-only-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [no-only-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-only-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/0c58a71767ca67097321b91f0332f543fc719389...master#diff-b7318d07931729c026fb1f61e9734468) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-only-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # S'assurer qu'aucun `test.only()` soit présent
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-only-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-only-test.md
@@ -1,6 +1,11 @@
-# Ensure no `test.only()` are present
+___
+**Note du traducteur**
 
-It's easy to run only one test with `test.only()` and then forget about it. It's visible in the results, but still easily missed. Forgetting to remove `.only`, means only this one test in the whole file will run, and if not caught, can let serious bugs slip into your codebase.
+C'est la traduction du fichier [no-only-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-only-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/0c58a71767ca67097321b91f0332f543fc719389...master#diff-b7318d07931729c026fb1f61e9734468) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-only-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer qu'aucun `test.only()` soit présent
+
+Il est facile d'exécuter un unique test avec `test.only()` et puis de l'oublier. Il est visible dans les résultats, mais on peut encore facilement le manquer. En oubliant d'enlever `.only`, cela signifie que seul ce test dans le fichier complet s'exécutera, et si on ne fait rien, ceci peut permettre de glisser de sérieux bugs dans votre code.
 
 
 ## Échoue
@@ -12,7 +17,7 @@ test.only('test 1', t => {
 	t.pass();
 });
 
-// test 2 will not run
+// test 2 ne s'exécutera pas
 test('test 2', t => {
 	t.pass();
 });
@@ -28,7 +33,7 @@ test('test 1', t => {
 	t.pass();
 });
 
-// test 2 will run
+// test 2 s'exécutera
 test('test 2', t => {
 	t.pass();
 });

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-assert.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-assert.md
@@ -1,6 +1,11 @@
-# Ensure no assertions are skipped
+___
+**Note du traducteur**
 
-It's easy to make an assertion skipped with `t.skip.xyz()` and then forget about it.
+C'est la traduction du fichier [no-skip-assert.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-skip-assert.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/199b7c1ba81d5a92c13440de49d69c3cf49d34dc...master#diff-5a0e2d6d6e66efe6059e266a9b4f5456) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-skip-assert.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer qu'aucune assertion soit passée (skip)
+
+C'est facile de sauter une assertion avec `t.skip.xyz()` et de l'oublier.
 
 
 ## Échoue
@@ -8,7 +13,7 @@ It's easy to make an assertion skipped with `t.skip.xyz()` and then forget about
 ```js
 import test from 'ava';
 
-test('some title', t => {
+test('un titre', t => {
 	t.skip.is(1, 1);
 });
 ```
@@ -19,7 +24,7 @@ test('some title', t => {
 ```js
 import test from 'ava';
 
-test('some title', t => {
+test('un titre', t => {
 	t.is(1, 1);
 });
 ```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-assert.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-assert.md
@@ -1,0 +1,25 @@
+# Ensure no assertions are skipped
+
+It's easy to make an assertion skipped with `t.skip.xyz()` and then forget about it.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test('some title', t => {
+	t.skip.is(1, 1);
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test('some title', t => {
+	t.is(1, 1);
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-test.md
@@ -1,0 +1,33 @@
+# Ensure no tests are skipped
+
+It's easy to make a test skipped with test.skip() and then forget about it. It's visible in the results, but still easily missed.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+test.skip('bar', t => {
+	t.pass();
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+test('bar', t => {
+	t.pass();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-skip-test.md
@@ -1,6 +1,11 @@
-# Ensure no tests are skipped
+___
+**Note du traducteur**
 
-It's easy to make a test skipped with test.skip() and then forget about it. It's visible in the results, but still easily missed.
+C'est la traduction du fichier [no-skip-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-skip-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/39bf10ba7ffe7b0b54c7fe636a6d240cd9a48d88...master#diff-c9c8947bbb8248704dc64c3f0418475c) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-skip-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer qu'aucun test soit passé (skip)
+
+Il est facile de faire sauter un test avec `test.skip()`, puis de l'oublier. Il est visible dans les résultats, mais on peut encore facilement le manquer.
 
 
 ## Échoue

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-statement-after-end.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-statement-after-end.md
@@ -1,4 +1,9 @@
-# Ensure `t.end()` is the last statement executed.
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [no-statement-after-end.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-statement-after-end.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/4a7f0b5357d35c4c56917832e53f36f93582fed1...master#diff-022e4562e2cef684c01e72e8a54af79f) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-statement-after-end.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que `t.end()` soit la dernière instruction exécutée
 
 `t.end()` should mark the end of your test, and additional statements should not be executed.
 
@@ -14,7 +19,7 @@ test.cb(t => {
 
 test.cb(t => {
 	t.end();
-	console.log('at the end');
+	console.log('à la fin');
 });
 ```
 
@@ -32,7 +37,7 @@ import test from 'ava';
 
 test.cb(t => {
 	if (a) {
-		// Allowed because no further statements are reachable.
+		// Autorisé, car aucune nouvelle déclaration n'est réalisable
 		return t.end();
 	}
 	if (b) {

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-statement-after-end.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-statement-after-end.md
@@ -1,0 +1,46 @@
+# Ensure `t.end()` is the last statement executed.
+
+`t.end()` should mark the end of your test, and additional statements should not be executed.
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test.cb(t => {
+	t.end();
+	t.is(1, 1);
+});
+
+test.cb(t => {
+	t.end();
+	console.log('at the end');
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test.cb(t => {
+	t.is(1, 1);
+	t.end();
+});
+import test from 'ava';
+
+test.cb(t => {
+	if (a) {
+		// Allowed because no further statements are reachable.
+		return t.end();
+	}
+	if (b) {
+		t.end();
+		return;
+	}
+	t.is(1, 1);
+	t.end();
+});
+
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-todo-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-todo-test.md
@@ -1,6 +1,11 @@
-# Ensure no `test.todo()` is used
+___
+**Note du traducteur**
 
-Disallow the use of `test.todo()`. You might want to do this to only ship features with specs fully written and passing.
+C'est la traduction du fichier [no-todo-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-todo-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/2908de51778b76f5398be0e566baae23cab5fa1d...master#diff-ee78ff1db3f63a4c5de48c6c6c18fcdd) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-todo-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer qu'aucun `test.todo()` soit utilisé
+
+Interdit l'utilisation de `test.todo()`. Vous pouvez effectuer cette opération pour seulement embarquer des fonctionnalités avec des spécifications entièrement écrites et qui passent.
 
 
 ## Échoue
@@ -18,6 +23,6 @@ test.todo('quelques tests');
 import test from 'ava';
 
 test('quelques tests', t => {
-	// Some implementation
+	// quelques implémentations
 });
 ```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-todo-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-todo-test.md
@@ -1,0 +1,23 @@
+# Ensure no `test.todo()` is used
+
+Disallow the use of `test.todo()`. You might want to do this to only ship features with specs fully written and passing.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test.todo('quelques tests');
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test('quelques tests', t => {
+	// Some implementation
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-unknown-modifiers.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-unknown-modifiers.md
@@ -1,0 +1,28 @@
+# Prevent the use of unknown test modifiers
+
+Prevent the use of unknown test modifiers.
+
+
+## Échoue
+
+```js
+import test = from 'ava';
+
+test.onlu(t => {});
+test.seril(t => {});
+test.cb.onlu(t => {});
+test.beforeeach(t => {});
+test.unknown(t => {});
+```
+
+
+## Passe
+
+```js
+import test = from 'ava';
+
+test.only(t => {});
+test.serial(t => {});
+test.cb.only(t => {});
+test.beforeEach(t => {});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/no-unknown-modifiers.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/no-unknown-modifiers.md
@@ -1,6 +1,11 @@
-# Prevent the use of unknown test modifiers
+___
+**Note du traducteur**
 
-Prevent the use of unknown test modifiers.
+C'est la traduction du fichier [no-unknown-modifiers.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/no-unknown-modifiers.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/94f25b8d9c2ec440390e4f8f009fc4b6f42057a1...master#diff-a0ba13ebe08ce474c12d590c29c27bb5) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `no-unknown-modifiers.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# Empêcher l'utilisation de modificateurs de test inconnus
+
+Empêche l'utilisation de modificateurs de test inconnus.
 
 
 ## Échoue

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/prefer-power-assert.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/prefer-power-assert.md
@@ -5,7 +5,7 @@ C'est la traduction du fichier [prefer-power-assert.md](https://github.com/sindr
 ___
 # Autoriser uniquement l'utilisation des assertions qui n'ont pas d'alternatives dans power-assert
 
-- [`t.truthy()`](https://github.com/sindresorhus/ava#truthyvalue-message) __(Vous pouvez faire la [plupart des choses](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#messages-dassertions-améliorés) avec celui-ci)__
+- [`t.truthy()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#truthyvalue-message) __(Vous pouvez faire la [plupart des choses](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#messages-dassertions-améliorés) avec celui-ci)__
 - [`t.deepEqual()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#deepequalvalue-expected-message)
 - [`t.notDeepEqual()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#notdeepequalvalue-expected-message)
 - [`t.throws()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#throwsfunctionpromise-error-message)

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/prefer-power-assert.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/prefer-power-assert.md
@@ -1,0 +1,33 @@
+# Allow only use of the asserts that have no power-assert alternative.
+
+- [`t.truthy()`](https://github.com/sindresorhus/ava#truthyvalue-message) __(You can do [most things](https://github.com/sindresorhus/ava#enhanced-assertion-messages) with this one)__
+- [`t.deepEqual()`](https://github.com/sindresorhus/ava#deepequalvalue-expected-message)
+- [`t.notDeepEqual()`](https://github.com/sindresorhus/ava#notdeepequalvalue-expected-message)
+- [`t.throws()`](https://github.com/sindresorhus/ava#throwsfunctionpromise-error-message)
+- [`t.notThrows()`](https://github.com/sindresorhus/ava#notthrowsfunctionpromise-message)
+- [`t.pass()`](https://github.com/sindresorhus/ava#passmessage)
+- [`t.fail()`](https://github.com/sindresorhus/ava#failmessage)
+
+Useful for people wanting to fully embrace the power of [power-assert](https://github.com/power-assert-js/power-assert).
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.is(foo, bar);
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.truthy(foo === bar);
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/prefer-power-assert.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/prefer-power-assert.md
@@ -1,14 +1,19 @@
-# Allow only use of the asserts that have no power-assert alternative.
+___
+**Note du traducteur**
 
-- [`t.truthy()`](https://github.com/sindresorhus/ava#truthyvalue-message) __(You can do [most things](https://github.com/sindresorhus/ava#enhanced-assertion-messages) with this one)__
-- [`t.deepEqual()`](https://github.com/sindresorhus/ava#deepequalvalue-expected-message)
-- [`t.notDeepEqual()`](https://github.com/sindresorhus/ava#notdeepequalvalue-expected-message)
-- [`t.throws()`](https://github.com/sindresorhus/ava#throwsfunctionpromise-error-message)
-- [`t.notThrows()`](https://github.com/sindresorhus/ava#notthrowsfunctionpromise-message)
-- [`t.pass()`](https://github.com/sindresorhus/ava#passmessage)
-- [`t.fail()`](https://github.com/sindresorhus/ava#failmessage)
+C'est la traduction du fichier [prefer-power-assert.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/prefer-power-assert.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/9eaf1cde7f4789cc2f59a7627a1c21c0d827a2bd...master#diff-1172258630db86b27c631226ec642918) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `prefer-power-assert.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# Autoriser uniquement l'utilisation des assertions qui n'ont pas d'alternatives dans power-assert
 
-Useful for people wanting to fully embrace the power of [power-assert](https://github.com/power-assert-js/power-assert).
+- [`t.truthy()`](https://github.com/sindresorhus/ava#truthyvalue-message) __(Vous pouvez faire la [plupart des choses](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#messages-dassertions-améliorés) avec celui-ci)__
+- [`t.deepEqual()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#deepequalvalue-expected-message)
+- [`t.notDeepEqual()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#notdeepequalvalue-expected-message)
+- [`t.throws()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#throwsfunctionpromise-error-message)
+- [`t.notThrows()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#notthrowsfunctionpromise-message)
+- [`t.pass()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#passmessage)
+- [`t.fail()`](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/readme.md#failmessage)
+
+Utile pour les personnes voulant complètement comprendre la puissance de [power-assert](https://github.com/power-assert-js/power-assert).
 
 
 ## Échoue

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/test-ended.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/test-ended.md
@@ -1,6 +1,11 @@
-# Ensure callback tests are explicitly ended
+___
+**Note du traducteur**
 
-If you forget a `t.end();` in `test.cb()` the test will hang indefinitely.
+C'est la traduction du fichier [test-ended.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/test-ended.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/793466a2b4f7c56234bd31698a93f7c9fd192632...master#diff-1a18b5ae66bcbafffe3be0ff7f18fa26) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `test-ended.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que les tests de callback soient explicitement terminés
+
+Si vous oubliez un `t.end();` dans un `test.cb()`, le test sera suspendu indéfiniment.
 
 
 ## Échoue

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/test-ended.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/test-ended.md
@@ -1,0 +1,30 @@
+# Ensure callback tests are explicitly ended
+
+If you forget a `t.end();` in `test.cb()` the test will hang indefinitely.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test.cb(t => {
+	t.pass();
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test.cb(t => {
+	t.pass();
+	t.end();
+});
+
+test.cb(t => {
+	acceptsCallback(t.end);
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/test-title.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/test-title.md
@@ -1,6 +1,11 @@
-# Ensure tests have a title
+___
+**Note du traducteur**
 
-Tests should have a title.
+C'est la traduction du fichier [test-title.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/test-title.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/b6d066728f507b03d00004833dbfe68f5a47118c...master#diff-ed02b0af8dd256929d27a1e08192e303) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `test-title.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que les tests ont un titre
+
+Les tests devraient avoir un titre.
 
 
 ## Échoue
@@ -50,9 +55,9 @@ test('foo', t => {
 
 ## Options
 
-The rule takes one option, a string, which could be either `"always"` or `"if-multiple"`. The default is `"if-multiple"`. If the option is set to `"if-multiple"`, the rule will only trigger if there are multiple tests in a file.
+La règle prend une option, un string, qui peut être soit `"always"` (toujours) ou soit `"if-multiple"` (si-plusieurs). La valeur par défaut est `"if-multiple"`. Si l'option est définie à `"if-multiple"`, la règle se déclenche que s'il y a plusieurs tests dans un fichier.
 
-You can set the option in configuration like this:
+Vous pouvez définir l'option dans la configuration comme ceci :
 
 ```js
 "ava/test-title": ["error", "always"]

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/test-title.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/test-title.md
@@ -1,0 +1,59 @@
+# Ensure tests have a title
+
+Tests should have a title.
+
+
+## Échoue
+
+```js
+/*eslint ava/test-title: ["error", "if-multiple"]*/
+import test from 'ava';
+
+test(t => {
+	t.pass();
+});
+
+test(t => {
+	t.pass();
+});
+
+/*eslint ava/test-title: ["error", "always"]*/
+import test from 'ava';
+
+test(t => {
+	t.pass();
+});
+```
+
+
+## Passe
+
+```js
+/*eslint ava/test-title: ["error", "if-multiple"]*/
+import test from 'ava';
+
+test(t => {
+	t.pass();
+});
+
+test('foo', t => {
+	t.pass();
+});
+
+/*eslint ava/test-title: ["error", "always"]*/
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+```
+
+## Options
+
+The rule takes one option, a string, which could be either `"always"` or `"if-multiple"`. The default is `"if-multiple"`. If the option is set to `"if-multiple"`, the rule will only trigger if there are multiple tests in a file.
+
+You can set the option in configuration like this:
+
+```js
+"ava/test-title": ["error", "always"]
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/use-t-well.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/use-t-well.md
@@ -1,0 +1,38 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [use-t-well.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/use-t-well.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/1a67712eeed92f5772b62c80530f31da3a32de5d...master#diff-732d970806d109613f5519b63e9056d8) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `use-t-well.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# Empêcher une mauvaise utilisation de `t`
+
+Empêche l'utilisation de méthodes d'assertion inconnues et empêche d'accèder à des méthodes différentes des assertions et de `context`, ainsi que certaines utilisations incorrectes connues de `t`.
+
+
+## Échoue
+
+```js
+import test from 'ava';
+
+test(t => {
+	t(value); // `t` n'est pas une fonction
+	t.depEqual(value, [2]); // Méthode d'assertion inconnue
+	t.contxt.foo = 100; // Membre `context` inconnu
+	t.foo = 1000; // Membre `foo` inconnu. Utilisez à la place `context.foo`
+	t.deepEqual.is(value, value); // Ne peut pas chainer des méthodes d'assertion
+	t.skip(); // Manque la méthode d'assertion
+	t.deepEqual.skip.skip(); // Trop nombreuses utilisations enchaînées de `skip`
+});
+```
+
+
+## Passe
+
+```js
+import test from 'ava';
+
+test(t => {
+	t.deepEqual(value, [2]);
+	t.context.a = 100;
+	t.deepEqual.skip();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/use-t.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/use-t.md
@@ -1,0 +1,35 @@
+# Ensure test functions use `t` as their parameter
+
+The convention is to have the parameter in AVA's test function be named `t`. Most rules in `eslint-plugin-ava` are based on that assumption.
+
+### Échoue
+
+```js
+import test from 'ava';
+
+test(foo => { // Incorrect name
+	t.pass();
+});
+
+test((t, bar) => { // too many arguments
+	t.pass();
+});
+
+test((bar, t) => { // too many arguments
+	t.pass();
+});
+```
+
+### Passe
+
+```js
+import test from 'ava';
+
+test(() => {
+	// ...
+});
+
+test(t => {
+	t.pass();
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/use-t.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/use-t.md
@@ -1,21 +1,26 @@
-# Ensure test functions use `t` as their parameter
+___
+**Note du traducteur**
 
-The convention is to have the parameter in AVA's test function be named `t`. Most rules in `eslint-plugin-ava` are based on that assumption.
+C'est la traduction du fichier [use-t.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/use-t.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/143c0bacbd3a9f636151d193414ffb2662283913...master#diff-17ed83dfe5d8198bdea74504bceedceb) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `use-t.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que les fonctions de test utilisent `t` comme paramètre
+
+La convention veut que le paramètre dans la fonction de test de AVA soit nommé `t`. La plupart des règles dans `eslint-plugin-ava` sont basées sur cette hypothèse.
 
 ### Échoue
 
 ```js
 import test from 'ava';
 
-test(foo => { // Incorrect name
+test(foo => { // Nom incorrect
 	t.pass();
 });
 
-test((t, bar) => { // too many arguments
+test((t, bar) => { // trop d'arguments
 	t.pass();
 });
 
-test((bar, t) => { // too many arguments
+test((bar, t) => { // trop d'arguments
 	t.pass();
 });
 ```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md
@@ -1,0 +1,24 @@
+# Ensure that AVA is imported with `test` as the variable name
+
+The convention is to import AVA and assign it to a variable named `test`. Most rules in `eslint-plugin-ava` are based on that assumption.
+
+### Échoue
+
+```js
+var ava = require('ava');
+let ava = require('ava');
+const ava = require('ava');
+import ava from 'ava';
+```
+
+### Passe
+
+```js
+var test = require('ava');
+let test = require('ava');
+const test = require('ava');
+import test from 'ava';
+
+var test = require('foo');
+import test from 'foo';
+```

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/use-test.md
@@ -1,6 +1,11 @@
-# Ensure that AVA is imported with `test` as the variable name
+___
+**Note du traducteur**
 
-The convention is to import AVA and assign it to a variable named `test`. Most rules in `eslint-plugin-ava` are based on that assumption.
+C'est la traduction du fichier [use-test.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/use-test.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/5ace84630a5b64aad18b9c04b2d6c5196f6e76bc...master#diff-fa3d5dae0f30fb7e10aa7481e3d528b1) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `use-test.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que AVA est importé avec la variable nommée `test`
+
+La convention est d'importer AVA et de l'affecter à une variable nommée `test`. La plupart des règles dans `eslint-plugin-ava` sont basées sur cette hypothèse.
 
 ### Échoue
 

--- a/fr_FR/related/eslint-plugin-ava/docs/rules/use-true-false.md
+++ b/fr_FR/related/eslint-plugin-ava/docs/rules/use-true-false.md
@@ -1,0 +1,38 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [use-true-false.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/use-true-false.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/8e9c5653aac4bbf1e13bb465fcfbbb23a902abd3...master#diff-ddb8eec6553e62e35444366d67672f38) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `use-true-false.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# S'assurer que `t.true()`/`t.false()` sont utilisés à la place de `t.truthy()`/`t.falsy()`
+
+`t.true()` et `t.false()` sont plus strict que `t.truthy()` et `t.falsy`.
+Par exemple : si vous avez une fonction `foo()` qui retourne normalement `true`, mais retourne soudainement à la place `1`, `t.truthy(foo())` ne pourra pas attraper ce changement, alors que ce serait le cas avec `t.true(foo())`.
+Cette règle impose l'utilisation de `t.true()`/`t.false()` lorsque l'expression testée est connue pour retourner une valeur booléenne.
+
+### Échoue
+
+```js
+import ava from 'ava';
+
+test(t => {
+	t.truthy(value < 2);
+	t.truthy(value === 1);
+	t.falsy([1, 2, 3].indexOf(value) === -1);
+	t.falsy(!value);
+	t.truthy(!!value);
+});
+```
+
+### Passe
+
+```js
+import ava from 'ava';
+
+test(t => {
+	t.true(value < 2);
+	t.true(value === 1);
+	t.false([1, 2, 3].indexOf(value) === -1);
+	t.false(!value);
+	t.true(!!value);
+});
+```

--- a/fr_FR/related/eslint-plugin-ava/readme.md
+++ b/fr_FR/related/eslint-plugin-ava/readme.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [readme.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/readme.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/be7c84b3f624016155e446b1dba9eab9a64cd081...master#diff-0730bb7c2e8f9ea2438b52e419dd86c9) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `readme.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [readme.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/readme.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/be7c84b3f624016155e446b1dba9eab9a64cd081...master#diff-0730bb7c2e8f9ea2438b52e419dd86c9) vers les différences avec le master de eslint-plugin-ava (Si en cliquant sur le lien, vous ne trouvez pas le fichier `readme.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # eslint-plugin-ava [![Build Status](https://travis-ci.org/sindresorhus/eslint-plugin-ava.svg?branch=master)](https://travis-ci.org/sindresorhus/eslint-plugin-ava)
 

--- a/fr_FR/related/eslint-plugin-ava/readme.md
+++ b/fr_FR/related/eslint-plugin-ava/readme.md
@@ -1,0 +1,113 @@
+___
+**Note du traducteur**
+
+C'est la traduction du fichier [readme.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/readme.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/625080ddb948f849fa7b6c8acd623155e111e2b2...master#diff-0730bb7c2e8f9ea2438b52e419dd86c9) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `readme.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+___
+# eslint-plugin-ava [![Build Status](https://travis-ci.org/sindresorhus/eslint-plugin-ava.svg?branch=master)](https://travis-ci.org/sindresorhus/eslint-plugin-ava)
+
+> Règles ESLint pour [AVA](https://ava.li)
+
+
+## L'installation
+
+```
+$ npm install --save-dev eslint eslint-plugin-ava
+```
+
+
+## L'utilisation
+
+Configurez le dans le `package.json`.
+
+```json
+{
+	"name": "my-awesome-project",
+	"eslintConfig": {
+		"env": {
+			"es6": true
+		},
+		"parserOptions": {
+			"ecmaVersion": 6,
+			"sourceType": "module"
+		},
+		"plugins": [
+			"ava"
+		],
+		"rules": {
+			"ava/max-asserts": ["off", 5],
+			"ava/no-cb-test": "off",
+			"ava/no-identical-title": "error",
+			"ava/no-ignored-test-files": "error",
+			"ava/no-invalid-end": "error",
+			"ava/no-only-test": "error",
+			"ava/no-skip-assert": "error",
+			"ava/no-skip-test": "error",
+			"ava/no-statement-after-end": "error",
+			"ava/no-todo-test": "warn",
+			"ava/no-unknown-modifiers": "error",
+			"ava/prefer-power-assert": "off",
+			"ava/test-ended": "error",
+			"ava/test-title": ["error", "if-multiple"],
+			"ava/use-t": "error",
+			"ava/use-test": "error"
+		}
+	}
+}
+```
+
+
+## Les règles
+
+Les règles s'activeront uniquement dans les fichiers de test.
+
+- [max-asserts](docs/rules/max-asserts.md) - Limiter le nombre d'assertions dans un test.
+- [no-cb-test](docs/rules/no-cb-test.md) - S'assurer qu'aucun `test.cb()` n'est utilisé.
+- [no-identical-title](docs/rules/no-identical-title.md) - S'assurer que chaque test a un titre différent.
+- [no-ignored-test-files](docs/rules/no-ignored-test-files.md) - S'assurer qu'aucun test ne soit écrit dans des fichiers ignorés.
+- [no-invalid-end](docs/rules/no-invalid-end.md) - S'assurer que `t.end()` est seulement appelé dans `test.cb()`.
+- [no-only-test](docs/rules/no-only-test.md) - S'assurer qu'aucun `test.only()` soit présent.
+- [no-skip-assert](docs/rules/no-skip-assert.md) - S'assurer qu'aucune assertion soit passée (skip).
+- [no-skip-test](docs/rules/no-skip-test.md) - S'assurer qu'aucun test soit passé (skip).
+- [no-statement-after-end](docs/rules/no-statement-after-end.md) - S'assurer que `t.end()` soit la dernière instruction exécutée.
+- [no-todo-test](docs/rules/no-todo-test.md) - S'assurer qu'aucun `test.todo()` soit utilisé.
+- [no-unknown-modifiers](docs/rules/no-unknown-modifiers.md) - Empêcher l'utilisation de modificateurs de test inconnus.
+- [prefer-power-assert](docs/rules/prefer-power-assert.md) - Autoriser uniquement l'utilisation des assertions qui n'ont pas d'alternatives dans [power-assert](https://github.com/power-assert-js/power-assert).
+- [test-ended](docs/rules/test-ended.md) - S'assurer que les tests de callback soient explicitement terminés.
+- [test-title](docs/rules/test-title.md) - S'assurer que les tests ont un titre.
+- [use-t](docs/rules/use-t.md) - S'assurer que les fonctions de test utilisent `t` comme paramètre.
+- [use-test](docs/rules/use-test.md) - S'assurer que AVA est importé avec la variable nommée `test`.
+
+
+## Configuration recommandée
+
+Ce plugin exporte une [configuration recommandée](index.js#L9) (`recommended`) qui applique les bonnes pratiques.
+
+Pour activer cette configuration, utilisez la propriété `extends` dans votre `package.json`.
+
+```json
+{
+	"name": "my-awesome-project",
+	"eslintConfig": {
+		"extends": "plugin:ava/recommended",
+		"plugins": [
+			"ava"
+		]
+	}
+}
+```
+
+Consulter la [documentation ESLint](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) pour plus d'informations sur l'extension des fichier de configuration.
+
+**Remarque** : Cette configuration activera aussi correctement les [options du parser](http://eslint.org/docs/user-guide/configuring#specifying-parser-options) et de l'[environment](http://eslint.org/docs/user-guide/configuring#specifying-environments).
+
+
+## Auteurs
+
+- [Jeroen Engels](https://github.com/jfmengels)
+- [Takuto Wada](https://github.com/twada)
+- [Et nos supers contributeurs](https://github.com/sindresorhus/eslint-plugin-ava/graphs/contributors)
+
+
+## Licence
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/fr_FR/related/eslint-plugin-ava/readme.md
+++ b/fr_FR/related/eslint-plugin-ava/readme.md
@@ -1,7 +1,7 @@
 ___
 **Note du traducteur**
 
-C'est la traduction du fichier [readme.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/readme.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/625080ddb948f849fa7b6c8acd623155e111e2b2...master#diff-0730bb7c2e8f9ea2438b52e419dd86c9) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `readme.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
+C'est la traduction du fichier [readme.md](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/readme.md). Voici un [lien](https://github.com/sindresorhus/eslint-plugin-ava/compare/be7c84b3f624016155e446b1dba9eab9a64cd081...master#diff-0730bb7c2e8f9ea2438b52e419dd86c9) vers les différences avec le master de AVA (Si en cliquant sur le lien, vous ne trouvez pas le fichier `readme.md` parmi les fichiers modifiés, vous pouvez donc en déduire que la traduction est à jour).
 ___
 # eslint-plugin-ava [![Build Status](https://travis-ci.org/sindresorhus/eslint-plugin-ava.svg?branch=master)](https://travis-ci.org/sindresorhus/eslint-plugin-ava)
 
@@ -27,7 +27,7 @@ Configurez le dans le `package.json`.
 			"es6": true
 		},
 		"parserOptions": {
-			"ecmaVersion": 6,
+			"ecmaVersion": 7,
 			"sourceType": "module"
 		},
 		"plugins": [
@@ -60,6 +60,7 @@ Configurez le dans le `package.json`.
 
 Les règles s'activeront uniquement dans les fichiers de test.
 
+- [assertion-message](docs/rules/assertion-message.md) - Imposer ou interdir les messages d'assertion.
 - [max-asserts](docs/rules/max-asserts.md) - Limiter le nombre d'assertions dans un test.
 - [no-cb-test](docs/rules/no-cb-test.md) - S'assurer qu'aucun `test.cb()` n'est utilisé.
 - [no-identical-title](docs/rules/no-identical-title.md) - S'assurer que chaque test a un titre différent.
@@ -80,7 +81,7 @@ Les règles s'activeront uniquement dans les fichiers de test.
 
 ## Configuration recommandée
 
-Ce plugin exporte une [configuration recommandée](index.js#L9) (`recommended`) qui applique les bonnes pratiques.
+Ce plugin exporte une [configuration recommandée](https://github.com/sindresorhus/eslint-plugin-ava/blob/master/index.js) (`recommended`) qui applique les bonnes pratiques.
 
 Pour activer cette configuration, utilisez la propriété `extends` dans votre `package.json`.
 
@@ -88,26 +89,27 @@ Pour activer cette configuration, utilisez la propriété `extends` dans votre `
 {
 	"name": "my-awesome-project",
 	"eslintConfig": {
-		"extends": "plugin:ava/recommended",
 		"plugins": [
 			"ava"
-		]
+		],
+		"extends": "plugin:ava/recommended",
 	}
 }
 ```
 
 Consulter la [documentation ESLint](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) pour plus d'informations sur l'extension des fichier de configuration.
 
-**Remarque** : Cette configuration activera aussi correctement les [options du parser](http://eslint.org/docs/user-guide/configuring#specifying-parser-options) et de l'[environment](http://eslint.org/docs/user-guide/configuring#specifying-environments).
+**Remarque** : Cette configuration activera aussi correctement les [options du parser](http://eslint.org/docs/user-guide/configuring#specifying-parser-options) et de l'[environnement](http://eslint.org/docs/user-guide/configuring#specifying-environments).
 
 
 ## Auteurs
 
 - [Jeroen Engels](https://github.com/jfmengels)
 - [Takuto Wada](https://github.com/twada)
-- [Et nos supers contributeurs](https://github.com/sindresorhus/eslint-plugin-ava/graphs/contributors)
+
+[Et nos supers contributeurs](https://github.com/sindresorhus/eslint-plugin-ava/graphs/contributors)
 
 
 ## Licence
 
-MIT © [Sindre Sorhus](http://sindresorhus.com)
+MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/fr_FR/related/eslint-plugin-ava/readme.md
+++ b/fr_FR/related/eslint-plugin-ava/readme.md
@@ -34,6 +34,7 @@ Configurez le dans le `package.json`.
 			"ava"
 		],
 		"rules": {
+			"ava/assertion-message": ["off", "always"],
 			"ava/max-asserts": ["off", 5],
 			"ava/no-cb-test": "off",
 			"ava/no-identical-title": "error",
@@ -48,8 +49,10 @@ Configurez le dans le `package.json`.
 			"ava/prefer-power-assert": "off",
 			"ava/test-ended": "error",
 			"ava/test-title": ["error", "if-multiple"],
+			"ava/use-t-well": "error",
 			"ava/use-t": "error",
-			"ava/use-test": "error"
+			"ava/use-test": "error",
+			"ava/use-true-false": "error"
 		}
 	}
 }
@@ -75,8 +78,10 @@ Les règles s'activeront uniquement dans les fichiers de test.
 - [prefer-power-assert](docs/rules/prefer-power-assert.md) - Autoriser uniquement l'utilisation des assertions qui n'ont pas d'alternatives dans [power-assert](https://github.com/power-assert-js/power-assert).
 - [test-ended](docs/rules/test-ended.md) - S'assurer que les tests de callback soient explicitement terminés.
 - [test-title](docs/rules/test-title.md) - S'assurer que les tests ont un titre.
+- [use-t-well](docs/rules/use-t-well.md) - Empêcher une mauvaise utilisation de `t`.
 - [use-t](docs/rules/use-t.md) - S'assurer que les fonctions de test utilisent `t` comme paramètre.
 - [use-test](docs/rules/use-test.md) - S'assurer que AVA est importé avec la variable nommée `test`.
+- [use-true-false](docs/rules/use-true-false.md) - S'assurer que `t.true()`/`t.false()` sont utilisés à la place de `t.truthy()`/`t.falsy()`.
 
 
 ## Configuration recommandée
@@ -92,7 +97,7 @@ Pour activer cette configuration, utilisez la propriété `extends` dans votre `
 		"plugins": [
 			"ava"
 		],
-		"extends": "plugin:ava/recommended",
+		"extends": "plugin:ava/recommended"
 	}
 }
 ```


### PR DESCRIPTION
WIP translating documentation eslint-plugin-ava in french

As AVA, make the translation of eslint-plugin-ava documentation.
This WIP should allow validate the directory structure (The names and directory structure can be changed). Your opinion interests me. (cc @jfmengels @twada Your opinion interests me too)

Already done:
- [X] translate in french `readme.md`
- [X] translate in french `assertion-message.md`
- [X] translate in french `max-asserts.md`
- [X] translate in french `no-cb-test.md`
- [X] translate in french `no-identical-title.md`
- [X] translate in french `no-ignored-test-files.md`
- [X] translate in french `no-invalid-end.md`
- [X] translate in french `no-only-test.md`
- [X] translate in french `no-skip-assert.md`
- [X] translate in french `no-skip-test.md`
- [X] translate in french `no-statement-after-end.md`
- [X] translate in french `no-todo-test.md`
- [X] translate in french `no-unknown-modifiers.md`
- [X] translate in french `prefer-power-assert.md`
- [X] translate in french `test-ended.md`
- [X] translate in french `test-title.md`
- [X] translate in french `use-t-well.md`
- [X] translate in french `use-t.md`
- [X] translate in french `use-test.md`
- [X] translate in french `use-true-false.md`

And:
- [X] check corrects links in all files
