### PR TITLE
Fix file path typo in Italian browser testing docs

### DIFF
--- a/it_IT/docs/recipes/browser-testing.md
+++ b/it_IT/docs/recipes/browser-testing.md
@@ -28,7 +28,7 @@ $ npm install --save-dev browser-env
 
 ## Configurare browser-env
 
-Creare un file helper e salvarlo nella cartella `test/helper`. Questo assicura che AVA non lo consideri un file di test.
+Creare un file helper e salvarlo nella cartella `test/helpers`. Questo assicura che AVA non lo consideri un file di test.
 
 `test/helpers/setup-browser-env.js`:
 


### PR DESCRIPTION
fixed mismatching file path within the same example that could create confusion